### PR TITLE
Cart API deletion fix

### DIFF
--- a/marketmate/src/app/api/users/[id]/cart/[cartId]/route.ts
+++ b/marketmate/src/app/api/users/[id]/cart/[cartId]/route.ts
@@ -134,5 +134,14 @@ export async function DELETE(req: Request, { params: { id, cartId } }: { params:
       id: cartId,
     },
   });
+
+  const update = await prisma.user.update({
+    where: {
+      id,
+    },
+    data: {
+      cartId: null,
+    },
+  });
   return NextResponse.json({ message: "ok", status: 200, data: deleted });
 }


### PR DESCRIPTION
adding in user.cartId = null when the cart linked to a user is deleted using /api/user/[id]/cart/[cartId]/ DELETE method.
